### PR TITLE
Add on event

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at help@mono.co. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+### Summary
+
+For bug reports, include detailed steps to reproduce or a minimal reproduction of the issue
+
+### Other information
+
+For visual issues, include screenshots!
+
+Is this specific to one device, or does it happen on multiple devices?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to Mono Connect.js
+
+Thanks for contributing to Mono Connect.js!
+
+## Issues
+
+The Mono Connect.js makes it quick and easy to onboard users to Mono in your app. It works across all major javascript frameworks. We provide a out-of-the-box way to connect your users' financial details.
+
+If you're having general trouble with Mono Connect.js or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on [Slack](https://join.slack.com/t/devwithmono/shared_invite/zt-gvkqczzk-Ldt4FQpHtOL7FFTqh4Ux6A). We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+
+If you've found a bug in Mono Connect.js, please [let us know](https://github.com/withmono/connect.js/issues/new)! You may
+also want to check out our [issue template](https://github.com/withmono/connect.js/tree/main/.github/CODE_OF_CONDUCT.md).
+
+## Code review
+
+All pull requests will be reviewed by someone from Mono before merging. At
+Mono, we believe that code review is for explaining and having a discussion
+around code. For those new to code review, we strongly recommend [this
+video](https://www.youtube.com/watch?v=PJjmw9TRB7s) on "code review culture."
+
+## Code of Conduct
+
+Please be mindful of our [Code of Conduct](https://github.com/withmono/connect.js/tree/main/.github/CODE_OF_CONDUCT.md). This is your community, treat others with respect.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2021- Mono Technologies Nigeria Limited (https://mono.co)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -182,16 +182,16 @@ const connect = new Connect({
 
 Event names corespond to the `type` key returned by the raw event data. Possible options are in the table below.
 
-| Raw Event Type | eventName |
+| Event Name | Description |
 | ----------- | ----------- |
-| `mono.connect.widget_opened` | OPENED |
-| `mono.connect.on_exit` | EXIT |
-| `mono.connect.institution_selected` | INSTITUTION_SELECTED |
-| `mono.connect.auth_method_switched` | AUTH_METHOD_SWITCHED |
-| `mono.connect.login_attempt` | SUBMIT_CREDENTIALS |
-| `mono.connect.account_linked` | ACCOUNT_LINKED |
-| `mono.connect.account_selected` | ACCOUNT_SELECTED |
-| `mono.connect.error_occured` | ERROR |
+| OPENED | Triggered when the user opens the Connect Widget. |
+| EXIT | Triggered when the user closes the Connect Widget. |
+| INSTITUTION_SELECTED | Triggered when the user selects an institution. |
+| AUTH_METHOD_SWITCHED | Triggered when the user changes authentication method from internet to mobile banking, or vice versa. |
+| SUBMIT_CREDENTIALS | Triggered when the user presses Log in. |
+| ACCOUNT_LINKED | Triggered when the user successfully links their account. |
+| ACCOUNT_SELECTED | Triggered when the user selects a new account. |
+| ERROR | Triggered when the widget reports an error.|
 
 
 #### <a name="dataObject"></a> `data`

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ For complete information about Mono Connect, head to the [docs](https://docs.mon
 
 You can install the package using NPM or Yarn;
 
-```bash 
+```bash
   npm install @mono.co/connect.js
 ```
 or
-```bash 
+```bash
   yarn add @mono.co/connect.js
 ```
-    
+
 ## Usage
 Click the links below for detailed examples on how to use connect.js with your favourite framework;
 - [React](docs/examples/react.md)
@@ -43,7 +43,7 @@ Click the links below for detailed examples on how to use connect.js with your f
 - [`onLoad`](#onLoad)
 - [`onEvent`](#onEvent)
 
-### <a name="key"></a> `key` 
+### <a name="key"></a> `key`
 **Required**  
 This is your Mono public API key from the [Mono dashboard](https://app.withmono.com/apps).
 ```js
@@ -54,7 +54,7 @@ This is your Mono public API key from the [Mono dashboard](https://app.withmono.
 **Required**
 This function is called when a user has successfully onboarded their account. It should take a single String argument containing the token that can be [exchanged for an account id](https://docs.mono.co/reference/authentication-endpoint).
 ```js
-  new Connect({ 
+  new Connect({
     key: 'mono_public_key',
     onSuccess: (data) => {
       // in the case of authentication auth code is returned
@@ -62,14 +62,14 @@ This function is called when a user has successfully onboarded their account. It
       // in the case of direct debit payments
       // a charge object is return containing amount, transaction_reference, type...
       console.log("charge object", data);
-    } 
+    }
   });
 ```
 
 ### <a name="onClose"></a> `onClose`
 The optional closure is called when a user has specifically exited the Mono Connect flow (i.e. the widget is not visible to the user). It does not take any arguments.
 ```js
-  new Connect({ 
+  new Connect({
     key: 'mono_public_key',
     onSuccess: ({code}) => console.log("auth code", code),
     onClose: () => console.log("widget has been closed")
@@ -79,7 +79,7 @@ The optional closure is called when a user has specifically exited the Mono Conn
 ### <a name="onLoad"></a> `onLoad`
 This function is invoked the widget has been mounted unto the DOM. You can handle toggling your trigger button within this callback.
 ```js
-  new Connect({ 
+  new Connect({
     key: 'mono_public_key',
     onSuccess: ({code}) => console.log("auth code", code),
     onLoad: () => console.log("widget loaded successfully")
@@ -92,7 +92,7 @@ This optional function is called when certain events in the Mono Connect flow ha
 See the [data](#dataObject) object below for details.
 
 ```js
-  new Connect({ 
+  new Connect({
     key: 'mono_public_key',
     onSuccess: ({code}) => console.log("auth code", code),
     onEvent: (eventName, metadata) => { console.log(eventName); console.log(metadata) }
@@ -143,7 +143,7 @@ This method makes the widget visible to the user.
     key: 'mono_public_key',
     onSuccess: ({code}) => console.log("code", code),
   });
-  
+
   connect.setup();
   connect.open();
 ```
@@ -155,7 +155,7 @@ This method programatically hides the widget after it's been opened.
     key: 'mono_public_key',
     onSuccess: ({code}) => console.log("code", code),
   });
-  
+
   connect.setup();
   connect.open();
   // this closes the widget 5seconds after it has been opened
@@ -172,7 +172,7 @@ const connect = new Connect({
   onSuccess: ({code}) => console.log("code", code),
   onEvent: (eventName, data) => {
     console.log(eventName)
-    console.log(data)	
+    console.log(data)
   }
 });
 
@@ -197,7 +197,7 @@ Event names corespond to the `type` key returned by the raw event data. Possible
 #### <a name="dataObject"></a> `data`
 The data object returned from the onEvent callback.
 
-```json
+```js
 {
 	"reference": "ref_code_passed", // emitted in all events
 	"errorType": "ERORR_NAME", // emitted in ERROR
@@ -229,6 +229,3 @@ If you would like to contribute to the Mono Connect iOS SDK, please make sure to
 ## License
 
 [MIT](https://github.com/withmono/connect.js/tree/main/LICENSE) for more information.
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 
-# @mono.co/connect.js
+# Mono Connect.js
 
-connect.js is a javascript package that allows you to load the Mono connect widget in your app. It works across all major javascript frameworks.
+Mono Connect.js is a quick and secure way to link bank accounts to Mono from within your app. Mono Connect is a drop-in framework that handles connecting a financial institution to your app (credential validation, multi-factor authentication, error handling, etc). It works with all major javascript frameworks.
+
+For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, TransferPay) use the server-side [Mono API](https://docs.mono.co/docs/intro-to-mono-api).
+
+## Documentation
+
+For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/intro-to-mono-connect-widget).
 
 
-## Getting started 
+## Getting Started
 
-Before you begin, grab you API keys from Mono dashboard. You are required to have an account with Mono.
+1. Register on the [Mono](https://app.withmono.com/dashboard) website and get your public and secret keys.
+2. Setup a server to [exchange tokens](https://docs.mono.co/reference/authentication-endpoint) to access user financial data with your Mono secret key.
 
-Request for you API keys [here](https://app.withmono.com/register)
 
-### Installation
+## Installation
 
 You can install the package using NPM or Yarn;
 
@@ -31,23 +37,22 @@ Click the links below for detailed examples on how to use connect.js with your f
 > NOTE  
 > The list above is not exhaustive, you can use this package in other frontend javascript frameworks.
 ## Parameters
-- [`key`](README.md#key)
-- [`onSuccess`](README.md#onsuccess)
-- [`onClose`](README.md#onclose)
-- [`onLoad`](README.md#onload)
+- [`key`](#key)
+- [`onSuccess`](#onSuccess)
+- [`onClose`](#onClose)
+- [`onLoad`](#onLoad)
+- [`onEvent`](#onEvent)
 
-### `key` 
+### <a name="key"></a> `key` 
 **Required**  
-This is your Mono public API key gotten from the Mono [dashboard](https://app.withmono.com)
+This is your Mono public API key from the [Mono dashboard](https://app.withmono.com/apps).
 ```js
   new Connect({ key: 'mono_public_key' });
 ```
 
-### `onSuccess`      
+### <a name="onSuccess"></a> `onSuccess`      
 **Required**
-
-
-This is a callback function invoked when authentication or payment is successful.
+This function is called when a user has successfully onboarded their account. It should take a single String argument containing the token that can be [exchanged for an account id](https://docs.mono.co/reference/authentication-endpoint).
 ```js
   new Connect({ 
     key: 'mono_public_key',
@@ -60,10 +65,9 @@ This is a callback function invoked when authentication or payment is successful
     } 
   });
 ```
-Auth code returned after successful authentication is exchanged for customer account ID like explained in the [docs](https://docs.mono.co/reference/authentication-endpoint)
 
-### `onClose`
-This function is invoked when the widget is closed i.e not visible to the user.
+### <a name="onClose"></a> `onClose`
+The optional closure is called when a user has specifically exited the Mono Connect flow (i.e. the widget is not visible to the user). It does not take any arguments.
 ```js
   new Connect({ 
     key: 'mono_public_key',
@@ -72,8 +76,8 @@ This function is invoked when the widget is closed i.e not visible to the user.
   });
 ```
 
-### `onLoad`
-This function is invoked the widget has been mounted unto the DOM. You can handle toggling your trigger button within this callback. 
+### <a name="onLoad"></a> `onLoad`
+This function is invoked the widget has been mounted unto the DOM. You can handle toggling your trigger button within this callback.
 ```js
   new Connect({ 
     key: 'mono_public_key',
@@ -82,8 +86,11 @@ This function is invoked the widget has been mounted unto the DOM. You can handl
   });
 ```
 
-### `onEvent`
-This function is invoked when the widget state changes. You can handle toggling your trigger button within this callback. 
+### <a name="onEvent"></a> `onEvent`
+This optional function is called when certain events in the Mono Connect flow have occurred, for example, when the user selected an institution. This enables your application to gain further insight into the Mono Connect onboarding flow.
+
+See the [data](#dataObject) object below for details.
+
 ```js
   new Connect({ 
     key: 'mono_public_key',
@@ -100,6 +107,9 @@ This method is used to load the widget unto the DOM, the widget remains hidden a
   const connect = new Connect({
     key: 'mono_public_key',
     onSuccess: ({code}) => console.log("code", code),
+    onLoad: () => console.log("widget loaded successfully"),
+    onClose: () => console.log("widget has been closed"),
+	onEvent: (eventName, data) => {console.log(eventName); console.log(data)},
   });
   connect.setup();
 ```
@@ -152,4 +162,73 @@ This method programatically hides the widget after it's been opened.
   setTimeout(() => connect.close(), 5000)
 ```
 
-If you find any issue using this package please let us know by filing an issue right [here](https://github.com/withmono/connect.js/issues)
+### <a name="onEventCallback"></a> onEvent Callback
+
+The onEvent callback returns two paramters, [eventName](#eventName) a string containing the event name and [data](#dataObject) an object that contains event metadata.
+
+```js
+const connect = new Connect({
+  key: 'mono_public_key',
+  onSuccess: ({code}) => console.log("code", code),
+  onEvent: (eventName, data) => {
+    console.log(eventName)
+    console.log(data)	
+  }
+});
+
+```
+
+#### <a name="eventName"></a> `eventName`
+
+Event names corespond to the `type` key returned by the raw event data. Possible options are in the table below.
+
+| Raw Event Type | eventName |
+| ----------- | ----------- |
+| `mono.connect.widget_opened` | OPENED |
+| `mono.connect.on_exit` | EXIT |
+| `mono.connect.institution_selected` | INSTITUTION_SELECTED |
+| `mono.connect.auth_method_switched` | AUTH_METHOD_SWITCHED |
+| `mono.connect.login_attempt` | SUBMIT_CREDENTIALS |
+| `mono.connect.account_linked` | ACCOUNT_LINKED |
+| `mono.connect.account_selected` | ACCOUNT_SELECTED |
+| `mono.connect.error_occured` | ERROR |
+
+
+#### <a name="dataObject"></a> `data`
+The data object returned from the onEvent callback.
+
+```json
+{
+	"reference": "ref_code_passed", // emitted in all events
+	"errorType": "ERORR_NAME", // emitted in ERROR
+	"errorMessage": "An error occurred.", // emitted in ERORR
+	"mfaType": "OTP", // emitted in SUBMIT_MFA
+	"prevAuthMethod": "internet_banking", // emitted in AUTH_METHOD_SWITCHED
+	"authMethod": "mobile_banking", // emitted in AUTH_METHOD_SWITCHED and INSTITUTION_SELECTED
+	"pageName": "MFA", // emitted in EXIT
+	"selectedAccountsCount": 2 // emitted in ACCOUNT_SELECTED
+	"institution": { // emitted in ACCOUNT_LINKED and INSTITUTION_SELECTED
+	  "id": "66059eO033be88012",
+	  "name": "GTBank"
+	},   
+	"timestamp": 1234567890 // emitted in all events
+}
+```
+
+
+## Support
+If you're having general trouble with Mono Connect iOS SDK or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on [Slack](https://join.slack.com/t/devwithmono/shared_invite/zt-gvkqczzk-Ldt4FQpHtOL7FFTqh4Ux6A). We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+
+## Contributing
+
+If you find any issue using this package please let us know by filing an issue right [here](https://github.com/withmono/connect.js/issues).
+
+If you would like to contribute to the Mono Connect iOS SDK, please make sure to read our [contributor guidelines](https://github.com/withmono/connect.js/tree/main/CONTRIBUTING.md).
+
+
+## License
+
+[MIT](https://github.com/withmono/connect.js/tree/main/LICENSE) for more information.
+
+
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Click the links below for detailed examples on how to use connect.js with your f
 **Required**  
 This is your Mono public API key gotten from the Mono [dashboard](https://app.withmono.com)
 ```js
-  new Connect({ key: "test_pk_fb8PP3jYA0" });
+  new Connect({ key: 'mono_public_key' });
 ```
 
 ### `onSuccess`      
@@ -50,7 +50,7 @@ This is your Mono public API key gotten from the Mono [dashboard](https://app.wi
 This is a callback function invoked when authentication or payment is successful.
 ```js
   new Connect({ 
-    key: "test_pk_fb8PP3jYA0",
+    key: 'mono_public_key',
     onSuccess: (data) => {
       // in the case of authentication auth code is returned
       console.log("auth code", data.code);
@@ -66,7 +66,7 @@ Auth code returned after successful authentication is exchanged for customer acc
 This function is invoked when the widget is closed i.e not visible to the user.
 ```js
   new Connect({ 
-    key: "test_pk_fb8PP3jYA0",
+    key: 'mono_public_key',
     onSuccess: ({code}) => console.log("auth code", code),
     onClose: () => console.log("widget has been closed")
   });
@@ -76,9 +76,19 @@ This function is invoked when the widget is closed i.e not visible to the user.
 This function is invoked the widget has been mounted unto the DOM. You can handle toggling your trigger button within this callback. 
 ```js
   new Connect({ 
-    key: "test_pk_fb8PP3jYA0",
+    key: 'mono_public_key',
     onSuccess: ({code}) => console.log("auth code", code),
     onLoad: () => console.log("widget loaded successfully")
+  });
+```
+
+### `onEvent`
+This function is invoked when the widget state changes. You can handle toggling your trigger button within this callback. 
+```js
+  new Connect({ 
+    key: 'mono_public_key',
+    onSuccess: ({code}) => console.log("auth code", code),
+    onEvent: (eventName, metadata) => { console.log(eventName); console.log(metadata) }
   });
 ```
 

--- a/connect.js
+++ b/connect.js
@@ -28,7 +28,14 @@ function connect({
     rest = {};
   }
 
-  if(!(this instanceof connect)) return new connect({key, onClose, onSuccess, onLoad, onEvent, ...rest});
+  if(!(this instanceof connect)) return new connect({
+    key, 
+    onClose, 
+    onSuccess, 
+    onLoad, 
+    onEvent, 
+    ...rest
+  });
 
   this.key = key || isRequired("PUBLIC_KEY");
   this.config = {...rest};
@@ -125,8 +132,10 @@ connect.prototype.close = function () {
   this.onClose();
 }
 
+// Do not attach connect to window when imported server side. 
+// This makes the module safe to import in an isomorphic code base.
 if(typeof window !== "undefined") {
-  window.Connect = connect; // make connect available globally
+  window.Connect = connect;
 }
 
 module.exports = connect;

--- a/connect.js
+++ b/connect.js
@@ -26,7 +26,6 @@ function connect({
     onSuccess = arguments[1].onSuccess || isRequired("onSuccess callback");
     onLoad = arguments[1].onLoad || anonFunc;
     rest = {};
-    onEvent = arguments[1].onEvent || anonFunc;
   }
 
   if(!(this instanceof connect)) return new connect({key, onClose, onSuccess, onLoad, onEvent, ...rest});
@@ -69,18 +68,48 @@ connect.prototype.reauthorise = function (reauth_token) {
 
 /**connect object property to open widget/modal */
 connect.prototype.open = function () {
-  connect.prototype.utils.openWidget(this.onEvent);
+  connect.prototype.utils.openWidget();
 
   function handleEvents(event){
 
     switch(event.data.type) {
+      /* Old callbacks */
       case "mono.connect.widget.account_linked":
         this.onSuccess({...event.data.data});
-        this.onEvent('SUCCESS', connect.prototype.utils.metadata({code: event.data.data.code}));
+        this.onEvent('SUCCESS', event.data.data);
         connect.prototype.close(); // close widget on success
         break;
       case "mono.connect.widget.closed":
         connect.prototype.close();
+        break;
+      /* New onEvent callbacks */
+      /* LOADED event is not triggered here, look in utils.js */
+      case "mono.connect.widget_opened":
+        this.onEvent('OPENED', event.data.data);
+        break;
+      case "mono.connect.error_occured":
+        this.onEvent('ERROR', event.data.data);
+        break;
+      case "mono.connect.institution_selected":
+        this.onEvent('INSTITUTION_SELECTED', event.data.data);
+        break;
+      case "mono.connect.auth_method_switched":
+        this.onEvent('AUTH_METHOD_SWITCHED', event.data.data);
+        break;
+      case "mono.connect.on_exit":
+        this.onEvent('EXIT', event.data.data);
+        break;
+      case "mono.connect.login_attempt":
+        this.onEvent('SUBMIT_CREDENTIALS', event.data.data);
+        break;
+      case "mono.connect.mfa_submitted":
+        this.onEvent('SUBMIT_MFA', event.data.data);
+        break;
+      case "mono.connect.account_linked":
+        this.onEvent('ACCOUNT_LINKED', event.data.data);
+        break;
+      case "mono.connect.account_selected":
+        this.onEvent('ACCOUNT_SELECTED', event.data.data);
         break;
     }
   }
@@ -94,7 +123,6 @@ connect.prototype.close = function () {
   window.removeEventListener("message", this.eventHandler, false);
   connect.prototype.utils.closeWidget();
   this.onClose();
-  this.onEvent('CLOSED', connect.prototype.utils.metadata({}));
 }
 
 if(typeof window !== "undefined") {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mono.co/connect.js",
-  "version": "0.1.9",
-  "description": "Mono connect script",
+  "version": "0.2.0",
+  "description": "Mono Connect Library",
   "main": "index.js",
   "scripts": {
     "build": "./node_modules/.bin/webpack -p --config ./webpack.config.js"
@@ -18,8 +18,8 @@
     "connect",
     "widget"
   ],
-  "author": "Mono devs",
-  "license": "ISC",
+  "author": "Mono (https://mono.co/)",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/withmono/connect.js/issues"
   },

--- a/utils.js
+++ b/utils.js
@@ -23,7 +23,7 @@ var utils = () => {
         return source.searchParams.set(k, encodedVal);
       }
       source.searchParams.set(k, qs[k]);
-    })
+    });
 
     var container = document.createElement("div");
     container.setAttribute("id", "mono-connect--widget-div");
@@ -47,16 +47,17 @@ var utils = () => {
 
       // dispatch LOADED event
       let event = new Event("message");
-      event["data"] = {};
-      event["data"]["type"] = "mono.connect.widget_loaded";
-      event["data"]["data"] = {};
-      event["data"]["data"]["timestamp"] = Date.now();
+      let eventData = {
+        type: 'mono.connect.widget_loaded',
+        data: { timestamp: Date.now() }
+      };
 
+      event['data'] = Object.assign({}, eventData);
       window.dispatchEvent(event);
 
-      // manually trigger LOADED since connect does not listen for events until the widget is opened
+      // manually trigger LOADED since 
+      // connect does not listen for events until the widget is opened
       onevent('LOADED', event.data.data);
-
     }
 
     var loader = createLoader();
@@ -97,12 +98,13 @@ var utils = () => {
 
       // dispatch OPENED event
       let event = new Event("message");
-      event["data"] = {};
-      event["data"]["type"] = "mono.connect.widget_opened";
-      event["data"]["data"] = {};
-      event["data"]["data"]["timestamp"] = Date.now();
-      window.dispatchEvent(event);
+      let eventData = {
+        type: 'mono.connect.widget_opened',
+        data: { timestamp: Date.now() }
+      };
 
+      event["data"] = Object.assign({}, eventData);
+      window.dispatchEvent(event);
     }, 2000);
   }
 
@@ -126,25 +128,13 @@ var utils = () => {
   }
 
   function addStyle() {
-    var styleSheet = document.createElement("style");
+    let styleSheet = document.createElement("style");
     styleSheet.type = "text/css";
     styleSheet.innerText = loaderStyles;
     document.head.appendChild(styleSheet);
   }
 
-  function metadata(data){
-    data = data || {};
-
-    if(!data. timestamp){
-      data[" timestamp"] = Date.now();
-    }
-
-    return sorted;
-
-  }
-
   return {
-    metadata: metadata,
     openWidget: openWidget,
     closeWidget: closeWidget,
     createLoader: createLoader,

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var utils = () => {
-  
+
   function init(config) {
     // check if container and iframe is already rendered on the DOM
     if(
@@ -11,7 +11,7 @@ var utils = () => {
       document.getElementById('mono-connect--widget-div').remove();
     }
 
-    const { key, onload, qs } = config;
+    const { key, onload, qs, onevent } = config;
     const encodedKeys = ["data"];
     var source = new URL('https://connect.withmono.com');
     source.searchParams.set('key', key);
@@ -20,7 +20,7 @@ var utils = () => {
       if(encodedKeys.includes(k)) {
         const encodedVal = encodeURIComponent(JSON.stringify(qs[k]));
         return source.searchParams.set(k, encodedVal);
-      } 
+      }
       source.searchParams.set(k, qs[k]);
     })
 
@@ -43,6 +43,7 @@ var utils = () => {
         loader.style.display = "none";
       }
       onload()
+      onevent('LOADED', metadata({}))
     }
 
     var loader = createLoader();
@@ -67,8 +68,8 @@ var utils = () => {
     container.style.visibility = "hidden";
     frame.style.visibility = "hidden";
   }
-  
-  function openWidget() {
+
+  function openWidget(onEvent) {
     var container = document.getElementById("mono-connect--widget-div");
     var loader = document.getElementById("mono-connect-app-loader");
     var frame = document.getElementById("mono-connect--frame-id");
@@ -76,8 +77,10 @@ var utils = () => {
     container.style.display = "flex";
     loader.style.display = "block";
 
-    setTimeout(() => { 
-      turnOnVisibility(); 
+    onEvent('OPENED', metadata({}))
+
+    setTimeout(() => {
+      turnOnVisibility();
       frame.focus({preventScroll: false})
       container.focus({preventScroll: false})
     }, 2000);
@@ -109,7 +112,35 @@ var utils = () => {
     document.head.appendChild(styleSheet);
   }
 
+  function metadata(data){
+    data = data || {};
+
+    if(!data.error_code){
+      data['error_code'] = null;
+    }
+    if(!data. error_message){
+      data[' error_message'] = null;
+    }
+    if(!data.code){
+      data['code'] = null;
+    }
+    if(!data. timestamp){
+      data[' timestamp'] = Date.now();
+    }
+
+    var sorted = Object.keys(data)
+    .sort()
+    .reduce(function (acc, key) {
+        acc[key] = data[key];
+        return acc;
+    }, {});
+
+    return sorted;
+
+  }
+
   return {
+    metadata: metadata,
     openWidget: openWidget,
     closeWidget: closeWidget,
     createLoader: createLoader,


### PR DESCRIPTION
Added new optional onEvent function to Connect class. Returns parameters eventName: String, metadata: Object

eventName can be on of ['OPENED', 'CLOSED', 'LOADED', 'SUCCESS']
metadata returns an object with relevant information: 
{
code: String or null // the auth code to return to 
error_code: null // does not return anything for now, we can add this later if possible I'd like to pass more data from the connect.mono.co widget
" error_message": null // ditto
" timestamp": 1622225295275 // unix timestamp from epoch
}