### PR TITLE
Deprecate `reauth_token` in favor of `account`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,11 @@
 
 Mono Connect.js is a quick and secure way to link bank accounts to Mono from within your app. Mono Connect is a drop-in framework that handles connecting a financial institution to your app (credential validation, multi-factor authentication, error handling, etc). It works with all major javascript frameworks.
 
-For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, DirectPay) use the server-side [Mono API](https://docs.mono.co/docs/intro-to-mono-api).
-
-## Version 2.0.2 Public Beta
-
-<b>Important</b>: Version 2.0.2 is currently in the public beta phase. This means it's available for testing and feedback from the community. Please be aware that there may be bugs, and some features might undergo changes before the stable release.
-
-### How to Install the Beta Version
-
-To try out the beta version, use the following command:
-
-```bash
-npm install @mono.co/connect.js@2.0.2
-```
+For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, DirectPay) use the server-side [Mono API](https://docs.mono.co/api).
 
 ## Documentation
 
-For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/intro-to-mono-connect-widget).
+For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/financial-data/overview).
 
 ## Requirements
 Node 10 or higher.
@@ -27,8 +15,8 @@ Node 10 or higher.
 
 ## Getting Started
 
-1. Register on the [Mono](https://app.withmono.com/dashboard) website and get your public and secret keys.
-2. Setup a server to [exchange tokens](https://docs.mono.co/reference/authentication-endpoint) to access user financial data with your Mono secret key.
+1. Register on the [Mono](https://app.mono.com) website and get your public and secret keys.
+2. Setup a server to [exchange tokens](https://docs.mono.co/api/bank-data/authorisation/exchange-token) to access user financial data with your Mono secret key.
 
 
 ## Installation
@@ -68,7 +56,7 @@ Click the links below for detailed examples on how to use connect.js with your f
 
 ### <a name="key"></a> `key`
 **Required**  
-This is your Mono public API key from the [Mono dashboard](https://app.withmono.com/apps).
+This is your Mono public API key from the [Mono dashboard](https://app.mono.co/apps).
 ```js
 new Connect({ key: 'mono_public_key', scope: 'auth' });
 ```
@@ -219,12 +207,26 @@ const config = {
 connect.setup(config);
 ```
 
-### `reauthorise(reauth_code: string)`
+### `reauthorise(accountId: string)`
 This methods loads the reauth widget unto the DOM, the widget remains hidden after invoking this function until the `open()` method is called.   
 
-Reauthorisation of already authenticated accounts is done when MFA (Multi Factor Authentication) or 2FA is required by the institution or it has been setup by the user for security purposes before more data can be fetched from the account.
+Re-authorisation of already authenticated accounts is done when MFA (Multi Factor Authentication) or 2FA is required by the institution or it has been setup by the user for security purposes before more data can be fetched from the account.
 
-Check Mono [docs](https://docs.mono.co/reference/intro#reauth-code) on how to obtain `reauth_code` of an account.
+#### Fetching Account ID for previously linked account
+
+You can fetch the Account ID of a linked account from the [Mono dashboard](https://app.mono.co/customers) or [API](https://docs.mono.co/docs/customers).
+
+Alternatively, make an API call to the [Exchange Token Endpoint](https://api.withmono.com/v2/accounts/auth) with the code from a successful linking and your mono application secret key. If successful, this will return an Account ID.
+
+##### Sample request:
+```shell
+curl --request POST \
+  --url https://api.withmono.com/v2/accounts/auth \
+  --header 'Content-Type: application/json' \
+  --header 'accept: application/json' \
+  --header 'mono-sec-key: your_secret_key' \
+  --data '{"code":"string"}'
+```
 
 ```js
 const connect = new Connect({
@@ -232,12 +234,12 @@ const connect = new Connect({
   scope: 'auth',
   onSuccess: ({code}) => console.log("code", code),
 });
-connect.reauthorise("auth_fb8PP3jYA0");
+connect.reauthorise("account_xyz");
 ```
 
-| Parameter | Type     | Description                       |
-| :-------- | :------- | :-------------------------------- |
-| `reauth_code`      | `string` | **Required**. Reauth code of the account to be reauthorised |
+| Parameter   | Type     | Description                                        |
+|:------------| :------- |:---------------------------------------------------|
+| `accountId` | `string` | **Required**. ID of the account to be reauthorised |
 
 > NOTE  
 > the `reauthorise` method and `setup` method should be used separately. When used together, the last called method takes precedence.
@@ -258,7 +260,7 @@ connect.open();
 ```
 
 ### `close()`
-This method programatically hides the widget after it's been opened.
+This method programmatically hides the widget after it's been opened.
 ```js
 const connect = new Connect({
   key: 'mono_public_key',
@@ -276,7 +278,7 @@ setTimeout(() => connect.close(), 5000)
 
 ### <a name="onEventCallback"></a> onEvent Callback
 
-The onEvent callback returns two paramters, [eventName](#eventName) a string containing the event name and [data](#dataObject) an object that contains event metadata.
+The onEvent callback returns two parameters, [eventName](#eventName) a string containing the event name and [data](#dataObject) an object that contains event metadata.
 
 ```js
 const connect = new Connect({
@@ -299,7 +301,7 @@ const connect = new Connect({
 
 #### <a name="eventName"></a> `eventName`
 
-Event names corespond to the `type` key returned by the raw event data. Possible options are in the table below.
+Event names correspond to the `type` key returned by the raw event data. Possible options are in the table below.
 
 | Event Name | Description |
 | ----------- | ----------- |
@@ -336,7 +338,7 @@ The data object returned from the onEvent callback.
 
 
 ## Support
-If you're having general trouble with Mono Connect.js or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+If you're having general trouble with Mono Connect.js or your Mono integration, please reach out to us at <support@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
 
 ## Contributing
 

--- a/connect.js
+++ b/connect.js
@@ -66,7 +66,10 @@ connect.prototype.reauthorise = function (accountId) {
     key: this.key,
     qs: {
       ...this.config,
-      account: accountId,
+      data: {
+        ...(this.config.data || {}),
+        account: accountId,
+      },
     },
     onload: this.onLoad,
     onevent: this.onEvent

--- a/connect.js
+++ b/connect.js
@@ -52,15 +52,22 @@ connect.prototype.setup = function (setup_configuration = {}) {
   });
 }
 
-connect.prototype.reauthorise = function (reauth_token) {
-  if(!reauth_token) {
-    throw new Error("Re-auth token is required for reauthorisation");
+connect.prototype.reauthorise = function (accountId) {
+  if(!accountId) {
+    throw new Error("Account ID is required for re-authorisation");
+  }
+
+  if (typeof accountId !== "string") {
+    throw new Error("Invalid accountId: must be a string");
   }
 
   connect.prototype.utils.addStyle();
   connect.prototype.utils.init({
     key: this.key,
-    qs: {...this.config, reauth_token},
+    qs: {
+      ...this.config,
+      account: accountId,
+    },
     onload: this.onLoad,
     onevent: this.onEvent
   });

--- a/docs/examples/angular.md
+++ b/docs/examples/angular.md
@@ -34,9 +34,9 @@ export class MonoComponent implements OnInit {
 </button>
 ```
 
-## Reauthorisation 
+## Re-authorisation 
 
-You can reauthorise a user acount if required. Using the `reauthorise()` function. 
+You can reauthorise a user account if required. Using the `reauthorise()` function. 
 
 - Note, the `reauthorise()` function should be used in place of the `setup()` function. The two should not be used at the same time.
 
@@ -59,7 +59,7 @@ export class MonoComponent implements OnInit {
       onSuccess: ({ code }) => console.log(`Reauth successful: ${code}`)
     })
 
-    this.monoInstance.reauthorise("auth_vb6klH234ox")
+    this.monoInstance.reauthorise("account_xyz")
   }
 
   ngOnInit() {}

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -33,9 +33,9 @@ export default function IndexPage() {
 }
 ```
 
-## Reauthorisation 
+## Re-authorisation 
 
-You can reauthorise a user acount if required. Using the `reauthorise()` function. 
+You can reauthorise a user account if required. Using the `reauthorise()` function. 
 
 - Note, the `reauthorise()` function should be used in place of the `setup()` function. The two should not be used at the same time.
 
@@ -44,7 +44,7 @@ See example below;
 import { useState, useCallback } from "react";
 
 export default function IndexPage() {
-  const [reauthCode, setReauthCode] = useState("reauth_toKeN");
+  const [accountId, setAccountId] = useState("account_xyz");
   const [scriptLoaded, setScriptLoaded] = useState(false);
 
   const reauthenticate = useCallback(async () => {
@@ -57,7 +57,7 @@ export default function IndexPage() {
       onSuccess: ({ code }) => console.log(`Reauth successful: ${code}`),
     });
 
-    monoInstance.reauthorise(reauthCode);
+    monoInstance.reauthorise(accountId);
     monoInstance.open();
   }, []);
 

--- a/docs/examples/react.md
+++ b/docs/examples/react.md
@@ -28,9 +28,9 @@ export default function App() {
 }
 ```
 
-## Reauthorisation 
+## Re-authorisation 
 
-You can reauthorise a user acount if required. Using the `reauthorise()` function. 
+You can reauthorise a user account if required. Using the `reauthorise()` function. 
 
 - Note, the `reauthorise()` function should be used in place of the `setup()` function. The two should not be used at the same time.
 
@@ -51,8 +51,8 @@ export default function App() {
   }, [])
 
   function reauthoriseAccount() {
-    const reauth_token = "code_xyzUi8olavk";
-    monoConnect.reauthorise(reauth_token);
+    const accountId = "account_xyz";
+    monoConnect.reauthorise(accountId);
     monoConnect.open();
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mono.co/connect.js",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mono.co/connect.js",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mono.co/connect.js",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Mono Connect Library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR replaces `reauth_token` with `account` for account re-authorisation. The `account` field takes the Account ID of a previously linked account and passes that to the Connect Widget which then handles re-authorisation. This eliminates the need for partners to make an extra call to the [reauthorise endpoint](https://docs.mono.co/api/bank-data/reauth) for a `reauth_token`.


https://github.com/user-attachments/assets/1940fb15-3ced-4f29-9cb7-16ae44d07f3c

