### PR TITLE
Mono fx add documentation for account match feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,18 @@ new Connect({
 ```
 
 ### <a name="setupConfig"></a> `setupConfig`
-This optional configuration object is used as a way to load the Connect Widget directly to an institution login page. 
+The selectedInstitution object is used as a way to load the Connect Widget directly to an institution login page.
+The Account Match feature allows you to verify that the account number provided by a customer matches the account number returned from their linked bank account.
 
 
 ```js
 const config = {
   selectedInstitution: {
     id: "5f2d08c060b92e2888287706", // the id of the institution to load
-    auth_method: "internet_banking" // internet_banking or mobile_banking
-  }
+    auth_method: "internet_banking", // internet_banking or mobile_banking
+    account_number: "02605538421" // the customer's account number
+  },
+  check_account_match: true
 }
 
 connect.setup(config);

--- a/connect.js
+++ b/connect.js
@@ -9,7 +9,7 @@ const isRequired = (name) => { throw new Error(`${name} is required`); };
 /**
  * This function creates a connect object and returns it's properties
  * @param {*} key public key gotten from Mono dashboard - REQUIRED
- * @param {*} options optional params functions the be invoked on success, on load and on close
+ * @param {*} options optional params functions to be invoked on success, on load and on close
  */
 function connect({
   key,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mono.co/connect.js",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mono.co/connect.js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mono.co/connect.js",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mono.co/connect.js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Mono Connect Library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Mono fx add documentation for account match feature

## Summary
1. Updates `setupConfig` documentation section in README with payload options for the account match feature.